### PR TITLE
Give TransactionId a default value, remove it from README.md code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ var client = new TransactClient(configuration);
 var message = new TransactMessage()
 {
     CampaignId = "123456",
-    TransactionId = "Test-" + Guid.NewGuid().ToString()),
     Recipients = new List<TransactMessageRecipient>()
     {
         new TransactMessageRecipient()

--- a/src/Silverpop.Core/TransactMessageEncoder.cs
+++ b/src/Silverpop.Core/TransactMessageEncoder.cs
@@ -13,7 +13,8 @@ namespace Silverpop.Core
             var xml = new XElement(XName.Get("XTMAILING"));
 
             xml.SetElementValue(XName.Get("CAMPAIGN_ID"), message.CampaignId);
-            xml.SetElementValue(XName.Get("TRANSACTION_ID"), message.TransactionId);
+            xml.SetElementValue(XName.Get("TRANSACTION_ID"),
+                message.TransactionId ?? "dotnet-api-" + Guid.NewGuid().ToString());
             xml.SetElementValue(XName.Get("SHOW_ALL_SEND_DETAIL"), message.ShowAllSendDetail);
             xml.SetElementValue(XName.Get("SEND_AS_BATCH"), message.SendAsBatch);
             xml.SetElementValue(XName.Get("NO_RETRY_ON_FAILURE"), message.NoRetryOnFailure);

--- a/test/Silverpop.Core.Tests/TransactMessageEncoderTests.cs
+++ b/test/Silverpop.Core.Tests/TransactMessageEncoderTests.cs
@@ -16,7 +16,7 @@ namespace Silverpop.Core.Tests
 
             private static string EncodedMessage(
                 string campaignId = "001",
-                string transactionId = "123",
+                string transactionId = null,
                 bool showAllSendDetail = false,
                 bool sendAsBatch = false,
                 bool noRetryOnFailure = false,
@@ -76,6 +76,13 @@ namespace Silverpop.Core.Tests
             {
                 Assert.True(EncodedMessage(transactionId: "12345")
                     .Contains("<TRANSACTION_ID>12345</TRANSACTION_ID>"));
+            }
+
+            [Fact]
+            public void EncodesDefaultTransactionIdWhenNull()
+            {
+                Assert.True(Regex.Match(EncodedMessage(),
+                    @"<TRANSACTION_ID>dotnet-api-.{36}<\/TRANSACTION_ID>").Success);
             }
 
             [Fact]


### PR DESCRIPTION
- Set a default value for TransactionId if not specified
- Remove the TransactionId from the README.md code example
