### PR TITLE
Update README.md message batch information

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ TransactMessageResponse response = client.SendMessage(message);
 TransactMessageResponse response = await client.SendMessageAsync(message);
 ```
 
-**Send a message batch using the client *(11 - 5,000 recipients)***
+**Send a message batch using the client *(1 or more recipients -- intended for bulk usage rather than sending an email to a single user)***
 
 ```csharp
 // This may send multiple XML files to Silverpop depending on the number of recipients.
 IEnumerable<string> batchResponse = client.SendMessageBatch(message);
 ```
 
-**Send a message batch using the client asynchronously *(11 - 5,000 recipients)***
+**Send a message batch using the client asynchronously *(1 or more recipients -- intended for bulk usage rather than sending an email to a single user)***
 
 ```csharp
 // This may send multiple XML files to Silverpop depending on the number of recipients.


### PR DESCRIPTION
Remove the cap of 5,000 recipients from the README.md since message batches are split as necessary according to [`TransactClientConfiguration.MaxRecipientsPerBatchRequest`](https://github.com/ritterim/silverpop-dotnet-api/blob/f99645f6a276f0a6f9e77d1302250b6282489aaa/src/Silverpop.Client/TransactClientConfiguration.cs#L7) value.

Also, add more information for usage intent.
