### PR TITLE
Create TransactClientConfigurationSection for application use

### DIFF
--- a/src/Silverpop.Client/Silverpop.Client.csproj
+++ b/src/Silverpop.Client/Silverpop.Client.csproj
@@ -40,6 +40,7 @@
       <HintPath>..\..\packages\SSH.NET.2013.4.7\lib\net40\Renci.SshNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions">
@@ -64,6 +65,7 @@
     <Compile Include="Extensions\StreamExtensions.cs" />
     <Compile Include="ISilverpopCommunicationsClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TransactClientConfigurationSection.cs" />
     <Compile Include="TransactClient.cs" />
     <Compile Include="TransactClientConfiguration.cs" />
     <Compile Include="TransactClientException.cs" />

--- a/src/Silverpop.Client/TransactClient.cs
+++ b/src/Silverpop.Client/TransactClient.cs
@@ -2,6 +2,7 @@
 using Silverpop.Core;
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -305,6 +306,22 @@ namespace Silverpop.Client
                 OAuthClientSecret = oAuthClientSecret,
                 OAuthRefreshToken = oAuthRefreshToken
             });
+        }
+
+        /// <summary>
+        /// Create the TransactClient using application configuration.
+        /// </summary>
+        public static TransactClient CreateUsingConfiguration()
+        {
+            var configSection = TransactClientConfigurationSection.GetFromConfiguration();
+
+            if (configSection == null)
+                throw new InvalidOperationException(
+                    "Unable to create TransactClient using configuration.");
+
+            var config = new TransactClientConfiguration(configSection);
+
+            return new TransactClient(config);
         }
     }
 }

--- a/src/Silverpop.Client/TransactClientConfiguration.cs
+++ b/src/Silverpop.Client/TransactClientConfiguration.cs
@@ -7,6 +7,20 @@ namespace Silverpop.Client
         public const int MaxRecipientsPerBatchRequest = 5000;
         public const int MaxRecipientsPerNonBatchRequest = 10;
 
+        public TransactClientConfiguration()
+        {
+        }
+
+        public TransactClientConfiguration(TransactClientConfigurationSection section)
+        {
+            PodNumber = section.PodNumber;
+            Username = section.Username;
+            Password = section.Password;
+            OAuthClientId = section.OAuthClientId;
+            OAuthClientSecret = section.OAuthClientSecret;
+            OAuthRefreshToken = section.OAuthRefreshToken;
+        }
+
         private int? _podNumber;
 
         public int? PodNumber

--- a/src/Silverpop.Client/TransactClientConfigurationSection.cs
+++ b/src/Silverpop.Client/TransactClientConfigurationSection.cs
@@ -1,0 +1,31 @@
+﻿using System.Configuration;
+
+namespace Silverpop.Client
+{
+    public class TransactClientConfigurationSection : ConfigurationSection
+    {
+        [ConfigurationProperty("podNumber")]
+        public int PodNumber { get { return (int)this["podNumber"]; } }
+
+        [ConfigurationProperty("username")]
+        public string Username { get { return (string)this["username"]; } }
+
+        [ConfigurationProperty("password")]
+        public string Password { get { return (string)this["password"]; } }
+
+        [ConfigurationProperty("oAuthClientId")]
+        public string OAuthClientId { get { return (string)this["oAuthClientId"]; } }
+
+        [ConfigurationProperty("oAuthClientSecret")]
+        public string OAuthClientSecret { get { return (string)this["oAuthClientSecret"]; } }
+
+        [ConfigurationProperty("oAuthRefreshToken")]
+        public string OAuthRefreshToken { get { return (string)this["oAuthRefreshToken"]; } }
+
+        public static TransactClientConfigurationSection GetFromConfiguration()
+        {
+            return ConfigurationManager.GetSection("transactClientConfiguration")
+                as TransactClientConfigurationSection;
+        }
+    }
+}


### PR DESCRIPTION
Create a `TransactClientConfigurationSection` for application use, allowing hosting application configuration to be used for configuring silverpop-dotnet-api.
