### PR TITLE
Personalization tags fixes

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Silverpop.Core/Constants.cs
+++ b/src/Silverpop.Core/Constants.cs
@@ -1,0 +1,10 @@
+﻿using System.Reflection;
+
+namespace Silverpop.Core
+{
+    public static class Constants
+    {
+        public const BindingFlags DefaultPersonalizationTagsPropertyReflectionBindingFlags =
+            BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
+    }
+}

--- a/src/Silverpop.Core/Silverpop.Core.csproj
+++ b/src/Silverpop.Core/Silverpop.Core.csproj
@@ -44,6 +44,7 @@
     <Compile Include="..\..\common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Constants.cs" />
     <Compile Include="Extensions\IEnumerableExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SilverpopPersonalizationTag.cs" />

--- a/src/Silverpop.Core/TransactMessageEncoder.cs
+++ b/src/Silverpop.Core/TransactMessageEncoder.cs
@@ -71,6 +71,9 @@ namespace Silverpop.Core
 
         private static bool ContainsCDATASection(string str)
         {
+            if (string.IsNullOrWhiteSpace(str))
+                return false;
+
             return Regex.Match(str, @"<!\[CDATA\[(.|\n|\r)*]]>").Success;
         }
     }

--- a/src/Silverpop.Core/TransactMessageEncoder.cs
+++ b/src/Silverpop.Core/TransactMessageEncoder.cs
@@ -48,6 +48,10 @@ namespace Silverpop.Core
                 // Add PERSONALIZATION nodes for RECIPIENT
                 foreach (var personalizationTag in recipient.PersonalizationTags)
                 {
+                    if (string.IsNullOrWhiteSpace(personalizationTag.Name))
+                        throw new ArgumentException(
+                            "TransactMessageRecipientPersonalizationTag items must have a valid Name set.");
+
                     var personalizationXml = new XElement(XName.Get("PERSONALIZATION"));
 
                     personalizationXml.SetElementValue(XName.Get("TAG_NAME"), personalizationTag.Name);

--- a/src/Silverpop.Core/TransactMessageRecipient.cs
+++ b/src/Silverpop.Core/TransactMessageRecipient.cs
@@ -53,7 +53,7 @@ namespace Silverpop.Core
         // Adapted from: http://stackoverflow.com/a/4944547/941536
         private static IEnumerable<TransactMessageRecipientPersonalizationTag> GetTransactMessageRecipientPersonalizationTags(
             object source,
-            BindingFlags bindingAttr = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance)
+            BindingFlags bindingAttr = Constants.DefaultPersonalizationTagsPropertyReflectionBindingFlags)
         {
             var properties = source.GetType().GetProperties(bindingAttr);
             foreach (var property in properties)
@@ -61,11 +61,13 @@ namespace Silverpop.Core
                 var personalizationTagAttribute =
                     property.GetCustomAttribute<SilverpopPersonalizationTag>();
 
+                var propertyValue = property.GetValue(source, null);
+
                 yield return new TransactMessageRecipientPersonalizationTag(
                     personalizationTagAttribute != null
                         ? personalizationTagAttribute.Name
                         : property.Name,
-                    property.GetValue(source, null).ToString());
+                    propertyValue == null ? null : propertyValue.ToString());
             }
         }
     }

--- a/test/Silverpop.Core.Tests/TransactMessageEncoderTests.cs
+++ b/test/Silverpop.Core.Tests/TransactMessageEncoderTests.cs
@@ -230,6 +230,50 @@ namespace Silverpop.Core.Tests
                 }
 
                 [Fact]
+                public void PersonalizationTags_ThrowsWhenNameIsNull()
+                {
+                    var exception = Assert.Throws<ArgumentException>(
+                        () => EncodedMessage(recipients: new List<TransactMessageRecipient>()
+                              {
+                                  new TransactMessageRecipient()
+                                  {
+                                      EmailAddress = "test1@example.com",
+                                      BodyType = TransactMessageRecipientBodyType.Html,
+                                      PersonalizationTags = new List<TransactMessageRecipientPersonalizationTag>()
+                                      {
+                                          new TransactMessageRecipientPersonalizationTag(null, "some_value"),
+                                      }
+                                  }
+                              }));
+
+                    Assert.Equal(
+                        "TransactMessageRecipientPersonalizationTag items must have a valid Name set.",
+                        exception.Message);
+                }
+
+                [Fact]
+                public void PersonalizationTags_ThrowsWhenNameIsWhiteSpace()
+                {
+                    var exception = Assert.Throws<ArgumentException>(
+                        () => EncodedMessage(recipients: new List<TransactMessageRecipient>()
+                              {
+                                  new TransactMessageRecipient()
+                                  {
+                                      EmailAddress = "test1@example.com",
+                                      BodyType = TransactMessageRecipientBodyType.Html,
+                                      PersonalizationTags = new List<TransactMessageRecipientPersonalizationTag>()
+                                      {
+                                          new TransactMessageRecipientPersonalizationTag("   ", "some_value"),
+                                      }
+                                  }
+                              }));
+
+                    Assert.Equal(
+                        "TransactMessageRecipientPersonalizationTag items must have a valid Name set.",
+                        exception.Message);
+                }
+
+                [Fact]
                 public void BodyTypeDefaultsToHtml()
                 {
                     var recipientTag = Regex.Match(

--- a/test/Silverpop.Core.Tests/TransactMessageEncoderTests.cs
+++ b/test/Silverpop.Core.Tests/TransactMessageEncoderTests.cs
@@ -244,6 +244,28 @@ namespace Silverpop.Core.Tests
                     Assert.True(recipientTag
                         .Contains("<BODY_TYPE>HTML</BODY_TYPE>"));
                 }
+
+                [Fact]
+                public void DoesNotThrowForNullPersonalizationTagPropertyValue()
+                {
+                    var message = new TransactMessage()
+                    {
+                        Recipients = new List<TransactMessageRecipient>()
+                        {
+                            new TransactMessageRecipient()
+                            {
+                                EmailAddress = "test@example.com",
+                                PersonalizationTags = new List<TransactMessageRecipientPersonalizationTag>()
+                                {
+                                    new TransactMessageRecipientPersonalizationTag("some_property", null)
+                                }
+                            }
+                        }
+                    };
+
+                    Assert.DoesNotThrow(
+                        () => new TransactMessageEncoder().Encode(message));
+                }
             }
         }
     }

--- a/test/Silverpop.Core.Tests/TransactMessageRecipientTests.cs
+++ b/test/Silverpop.Core.Tests/TransactMessageRecipientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -110,6 +111,20 @@ namespace Silverpop.Core.Tests
 
                 Assert.Equal("Tag2", recipient.PersonalizationTags.Last().Name);
                 Assert.Equal("tag2-value", recipient.PersonalizationTags.Last().Value);
+            }
+
+            [Fact]
+            public void ShouldNotThrowWhenPersonalizationTagsDictionaryHasANullValue()
+            {
+                Assert.DoesNotThrow(
+                    () => new TransactMessageRecipient()
+                    {
+                        EmailAddress = "test@example.com",
+                        PersonalizationTags = new List<TransactMessageRecipientPersonalizationTag>()
+                        {
+                            new TransactMessageRecipientPersonalizationTag("Tag1", null)
+                        }
+                    });
             }
 
             [Fact]

--- a/test/Silverpop.Core.Tests/TransactMessageRecipientTests.cs
+++ b/test/Silverpop.Core.Tests/TransactMessageRecipientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -111,6 +110,27 @@ namespace Silverpop.Core.Tests
 
                 Assert.Equal("Tag2", recipient.PersonalizationTags.Last().Name);
                 Assert.Equal("tag2-value", recipient.PersonalizationTags.Last().Value);
+            }
+
+            [Fact]
+            public void ShouldNotThrowWhenPropertyInPersonalizationTagsObjectHasANullValue()
+            {
+                // Verify this test is valid when using the
+                // TestPersonalizationTagsWithSilverpopPersonalizationTag type.
+                var propertiesCount = new TestPersonalizationTagsWithSilverpopPersonalizationTag()
+                    .GetType()
+                    .GetProperties(Constants.DefaultPersonalizationTagsPropertyReflectionBindingFlags)
+                    .Count();
+
+                Assert.True(propertiesCount > 1);
+
+                Assert.DoesNotThrow(
+                    () => TransactMessageRecipient.Create<TestPersonalizationTagsWithSilverpopPersonalizationTag>(
+                        "test@example.com",
+                        new TestPersonalizationTagsWithSilverpopPersonalizationTag()
+                        {
+                            Tag1 = "tag1-value",
+                        }));
             }
 
             public class TestPersonalizationTagsWithSilverpopPersonalizationTag


### PR DESCRIPTION
Fix issues related to invalid personalization tag Name and Value. Guard against sending invalid information to Silverpop.

Release version 0.2.1.
