### PR TITLE
Move Constants into new Internal namespace

### DIFF
--- a/src/Silverpop.Core/Internal/Constants.cs
+++ b/src/Silverpop.Core/Internal/Constants.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
-namespace Silverpop.Core
+namespace Silverpop.Core.Internal
 {
     public static class Constants
     {

--- a/src/Silverpop.Core/Silverpop.Core.csproj
+++ b/src/Silverpop.Core/Silverpop.Core.csproj
@@ -44,7 +44,7 @@
     <Compile Include="..\..\common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="Constants.cs" />
+    <Compile Include="Internal\Constants.cs" />
     <Compile Include="Extensions\IEnumerableExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SilverpopPersonalizationTag.cs" />

--- a/src/Silverpop.Core/TransactMessageRecipient.cs
+++ b/src/Silverpop.Core/TransactMessageRecipient.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Silverpop.Core.Internal;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 

--- a/test/Silverpop.Core.Tests/TransactMessageRecipientTests.cs
+++ b/test/Silverpop.Core.Tests/TransactMessageRecipientTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Silverpop.Core.Internal;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;


### PR DESCRIPTION
Move the **Silverpop.Core.Constants** class into **Silverpop.Core.Internal.Constants** to avoid potential collision with other libraries.
