### PR TITLE
Move TransactMessageEncoder.BodyTypeDefault to Constants

### DIFF
--- a/src/Silverpop.Core/Internal/Constants.cs
+++ b/src/Silverpop.Core/Internal/Constants.cs
@@ -6,5 +6,8 @@ namespace Silverpop.Core.Internal
     {
         public const BindingFlags DefaultPersonalizationTagsPropertyReflectionBindingFlags =
             BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
+
+        public const TransactMessageRecipientBodyType TransactMessageBodyTypeDefault =
+            TransactMessageRecipientBodyType.Html;
     }
 }

--- a/src/Silverpop.Core/TransactMessageEncoder.cs
+++ b/src/Silverpop.Core/TransactMessageEncoder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Silverpop.Core.Internal;
+using System;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
@@ -6,9 +7,6 @@ namespace Silverpop.Core
 {
     public class TransactMessageEncoder
     {
-        private const TransactMessageRecipientBodyType BodyTypeDefault =
-            TransactMessageRecipientBodyType.Html;
-
         public virtual string Encode(TransactMessage message)
         {
             if (message == null) throw new ArgumentNullException("message");
@@ -42,7 +40,7 @@ namespace Silverpop.Core
 
                 recipientXml.SetElementValue(XName.Get("EMAIL"), recipient.EmailAddress);
 
-                var bodyType = recipient.BodyType ?? BodyTypeDefault;
+                var bodyType = recipient.BodyType ?? Constants.TransactMessageBodyTypeDefault;
                 recipientXml.SetElementValue(XName.Get("BODY_TYPE"), bodyType.ToString().ToUpper());
 
                 // Add PERSONALIZATION nodes for RECIPIENT

--- a/src/Silverpop.Core/TransactMessageRecipient.cs
+++ b/src/Silverpop.Core/TransactMessageRecipient.cs
@@ -20,7 +20,7 @@ namespace Silverpop.Core
 
         public static TransactMessageRecipient Create(
             string emailAddress,
-            TransactMessageRecipientBodyType? bodyType = TransactMessageRecipientBodyType.Html)
+            TransactMessageRecipientBodyType? bodyType = Constants.TransactMessageBodyTypeDefault)
         {
             if (emailAddress == null) throw new ArgumentNullException("emailAddress");
 

--- a/test/Silverpop.Core.Tests/TransactMessageEncoderTests.cs
+++ b/test/Silverpop.Core.Tests/TransactMessageEncoderTests.cs
@@ -1,4 +1,5 @@
-﻿using Silverpop.Core.Tests.Extensions;
+﻿using Silverpop.Core.Internal;
+using Silverpop.Core.Tests.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -212,7 +213,7 @@ namespace Silverpop.Core.Tests
                                   new TransactMessageRecipient()
                                   {
                                       EmailAddress = "test1@example.com",
-                                      BodyType = TransactMessageRecipientBodyType.Html,
+                                      BodyType = Constants.TransactMessageBodyTypeDefault,
                                       PersonalizationTags = new List<TransactMessageRecipientPersonalizationTag>()
                                       {
                                           new TransactMessageRecipientPersonalizationTag(
@@ -238,7 +239,7 @@ namespace Silverpop.Core.Tests
                                   new TransactMessageRecipient()
                                   {
                                       EmailAddress = "test1@example.com",
-                                      BodyType = TransactMessageRecipientBodyType.Html,
+                                      BodyType = Constants.TransactMessageBodyTypeDefault,
                                       PersonalizationTags = new List<TransactMessageRecipientPersonalizationTag>()
                                       {
                                           new TransactMessageRecipientPersonalizationTag(null, "some_value"),
@@ -260,7 +261,7 @@ namespace Silverpop.Core.Tests
                                   new TransactMessageRecipient()
                                   {
                                       EmailAddress = "test1@example.com",
-                                      BodyType = TransactMessageRecipientBodyType.Html,
+                                      BodyType = Constants.TransactMessageBodyTypeDefault,
                                       PersonalizationTags = new List<TransactMessageRecipientPersonalizationTag>()
                                       {
                                           new TransactMessageRecipientPersonalizationTag("   ", "some_value"),


### PR DESCRIPTION
Move **TransactMessageEncoder.BodyTypeDefault** to **Constants**.
- Renamed to Constants.TransactMessageBodyTypeDefault

Also, modify tests to use **Constants.TransactMessageBodyTypeDefault**.
