### PR TITLE
Update handling of null-value personalization tags

### DIFF
--- a/src/Silverpop.Core/TransactMessageEncoder.cs
+++ b/src/Silverpop.Core/TransactMessageEncoder.cs
@@ -60,7 +60,9 @@ namespace Silverpop.Core
                         throw new ArgumentException(
                             "XML CDATA sections should not be used in PersonalizationTags values.");
 
-                    personalizationXml.SetElementValue(XName.Get("VALUE"), personalizationTag.Value);
+                    personalizationXml.SetElementValue(
+                        XName.Get("VALUE"),
+                        personalizationTag.Value ?? string.Empty);
 
                     recipientXml.Add(personalizationXml);
                 }

--- a/test/Silverpop.Core.Tests/TransactMessageEncoderTests.cs
+++ b/test/Silverpop.Core.Tests/TransactMessageEncoderTests.cs
@@ -274,6 +274,25 @@ namespace Silverpop.Core.Tests
                 }
 
                 [Fact]
+                public void PersonalizationTags_HandlesWhenValueIsNull()
+                {
+                    var encodedMessage = EncodedMessage(recipients: new List<TransactMessageRecipient>()
+                    {
+                        new TransactMessageRecipient()
+                        {
+                            EmailAddress = "test1@example.com",
+                            BodyType = Constants.TransactMessageBodyTypeDefault,
+                            PersonalizationTags = new List<TransactMessageRecipientPersonalizationTag>()
+                            {
+                                new TransactMessageRecipientPersonalizationTag("tag1", null),
+                            }
+                        }
+                    });
+
+                    Assert.Contains("<VALUE></VALUE>", encodedMessage);
+                }
+
+                [Fact]
                 public void BodyTypeDefaultsToHtml()
                 {
                     var recipientTag = Regex.Match(


### PR DESCRIPTION
Previous behavior would generate invalid XML since Silverpop is expecting a `<PERSONALIZATION>`-tag to have a child `<VALUE>`-tag.
New behavior uses an empty string-value.
### Previous PersonalizationTag null-value Behavior

``` xml
<PERSONALIZATION>
    <TAG_NAME>test</TAG_NAME>
</PERSONALIZATION>
```
### Previous Silverpop Response

``` xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<XTMAILING_RESPONSE>
    <CAMPAIGN_ID>...</CAMPAIGN_ID>
    <TRANSACTION_ID>dotnet-api-...</TRANSACTION_ID>
    <RECIPIENTS_RECEIVED>1</RECIPIENTS_RECEIVED>
    <EMAILS_SENT>0</EMAILS_SENT>
    <NUMBER_ERRORS>1</NUMBER_ERRORS>
    <STATUS>2</STATUS>
    <ERROR_CODE>0</ERROR_CODE>
    <ERROR_STRING></ERROR_STRING>
    <RECIPIENT_DETAIL>
        <EMAIL>...</EMAIL>
        <SEND_STATUS>1</SEND_STATUS>
        <ERROR_CODE>4</ERROR_CODE>
        <ERROR_STRING>missing value</ERROR_STRING>
    </RECIPIENT_DETAIL>
</XTMAILING_RESPONSE>
```
### New PersonalizationTag null-value Behavior

``` xml
<PERSONALIZATION>
  <TAG_NAME>test</TAG_NAME>
  <VALUE></VALUE>
</PERSONALIZATION>
```
