### PR TITLE
 Use recipient details errors when no main error message exists

### DIFF
--- a/src/Silverpop.Client/Silverpop.Client.nuspec
+++ b/src/Silverpop.Client/Silverpop.Client.nuspec
@@ -3,7 +3,7 @@
   <metadata>
    <id>silverpop-dotnet-api</id>
     <title>Silverpop .NET API</title>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <authors>Ritter Insurance Marketing</authors>
     <description>This is a .NET API wrapper for Silverpop Transact XML email sending.</description>
     <projectUrl>https://github.com/ritterim/silverpop-dotnet-api</projectUrl>

--- a/src/Silverpop.Client/TransactClient.cs
+++ b/src/Silverpop.Client/TransactClient.cs
@@ -64,8 +64,21 @@ namespace Silverpop.Client
             var decodedResponse = _decoder.Decode(response);
 
             if (decodedResponse.Status == TransactMessageResponseStatus.EncounteredErrorsNoMessagesSent)
+            {
+                var errorMessage = decodedResponse.Error.Value;
+
+                if (string.IsNullOrWhiteSpace(errorMessage) && decodedResponse.RecipientDetails.Any())
+                {
+                    errorMessage = string.Join(
+                        "; ",
+                        decodedResponse.RecipientDetails
+                            .Where(x => x.SendStatus == TransactMessageResponseRecipientSendStatus.ErrorEncounteredWillNotRetry)
+                            .Select(x => $"{x.Email}: {(string.IsNullOrWhiteSpace(x.Error.Value) ? "Unknown error" : x.Error.Value)}"));
+                }
+
                 throw new TransactClientException(
-                    decodedResponse.Error.Value, encodedMessage, decodedResponse.RawResponse);
+                    errorMessage, encodedMessage, decodedResponse.RawResponse);
+            }
 
             return decodedResponse;
         }
@@ -87,8 +100,21 @@ namespace Silverpop.Client
             var decodedResponse = _decoder.Decode(response);
 
             if (decodedResponse.Status == TransactMessageResponseStatus.EncounteredErrorsNoMessagesSent)
+            {
+                var errorMessage = decodedResponse.Error.Value;
+
+                if (string.IsNullOrWhiteSpace(errorMessage) && decodedResponse.RecipientDetails.Any())
+                {
+                    errorMessage = string.Join(
+                        "; ",
+                        decodedResponse.RecipientDetails
+                            .Where(x => x.SendStatus == TransactMessageResponseRecipientSendStatus.ErrorEncounteredWillNotRetry)
+                            .Select(x => $"{x.Email}: {(string.IsNullOrWhiteSpace(x.Error.Value) ? "Unknown error" : x.Error.Value)}"));
+                }
+
                 throw new TransactClientException(
-                    decodedResponse.Error.Value, encodedMessage, decodedResponse.RawResponse);
+                    errorMessage, encodedMessage, decodedResponse.RawResponse);
+            }
 
             return decodedResponse;
         }


### PR DESCRIPTION
Releases `2.0.3`